### PR TITLE
0.12.0

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,3 +6,6 @@ channel_targets:
 - nsls2forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -45,8 +45,12 @@ fi
 if [ -z "${DOCKER_IMAGE}" ]; then
     SHYAML_INSTALLED="$(shyaml -h || echo NO)"
     if [ "${SHYAML_INSTALLED}" == "NO" ]; then
-        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
-        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
+        DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
+        if [ "${DOCKER_IMAGE}" = "" ]; then
+            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        fi
     else
         DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
     fi
@@ -64,8 +68,8 @@ fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xpdAcq" %}
-{% set version = "0.11.0" %}
-{% set sha256 = "540da95204e34b46ec392e21195a876c3fa478988f816022170f1bcc877b19ad" %}
+{% set version = "0.12.0" %}
+{% set sha256 = "f4e7beb7109a87426025009b0c5ec4667fdb7a46f199d7432b1e7d4bf028faa8" %}
 
 package:
   name: {{ name|lower }}
@@ -25,11 +25,11 @@ requirements:
     - databroker
     - ipython
     - numpy
+    - openpyxl
     - ophyd
     - pandas
     - pyfai
     - pyyaml
-    - xlrd
     - xpdan
     - xpdconf
     - xpdsim


### PR DESCRIPTION
New release.

https://github.com/xpdAcq/xpdAcq/releases/tag/0.12.0

v0.12.0
====================

**Added:**

* A tool to inject metadata using the preprocessors.

* Add dependency on the pyopenxl

**Changed:**

* Translation of scan plans no longer injects the sample metadata

**Removed:**

* Remove dependency on the xlrd

**Fixed:**

* Fix the bug that bsui cannot start because of the importing from pyFAI.gui

* Fix the bug that translation of samples and plans can give None or a list unexpectedly

* Fix the bug that the sample metadata is not injected in the start documents.